### PR TITLE
Assignment operator is not a caret

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ c   <- letters
 ![](inst/media/demo2.gif)
 
 ### What
-A very simple aligner for a highlighted region's single caret (`<-`) assignment operators. __It does not "reflow" your code if the alignment breaks the page width__ (it does not do anything like `Ctrl + Shift + /`). This addin also does not treat commented lines differently than uncommented lines. __If there is an assignment operator within a highlighted comment line, then it will either align that operator or align other operators to it.__
+A very simple aligner for a highlighted region's assignment operators (`<-`). __It does not "reflow" your code if the alignment breaks the page width__ (it does not do anything like `Ctrl + Shift + /`). This addin also does not treat commented lines differently to uncommented lines. __If there is an assignment operator within a highlighted comment line, then it will either align that operator or align other operators to it.__
 
 ### Install
 `devtools::install_github("seasmith/AlignAssign")`


### PR DESCRIPTION
Minor clarification.

Great work on this. I'll have a closer look and see if some regex can expand this to other characters also (e.g. = within multi-line argument lists).