### PR TITLE
Fix typo in guess_operator when falling back to max count of operators

### DIFF
--- a/R/align_assign.R
+++ b/R/align_assign.R
@@ -122,7 +122,7 @@ guess_operator <- function(area = captureArea(capture())) {
   some_ones <- vapply(lapply(counts, function(x) x == 1), sum, integer(1))
   all_same <- length(unique(counts)) == 1
   if (!all_same) {
-    return(names(which.max(counts)))
+    return(names(which.max(some_ones)))
   } else {
     warning("Couldn't guess the operator for alignment, trying ` <- `")
     return("<-")


### PR DESCRIPTION
I found a small typo in my code that would fail for code like

```r
var <- c(
  one = "a",
  two = "b",
  three = "c"
)
```

if the whole chunk was selected. The bug was just that the final return operated on the wrong object.
  